### PR TITLE
Loose requirements to use last pip version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 commit = True
 tag = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-casbin==0.8.4
+casbin>=0.8.4
 couchbase>=2.5.0,<3.0.0
-decorator==4.4.2
-py==1.9.0
+decorator>=4.4.2
+py>=1.9.0
 retry==0.9.2
 simpleeval==0.9.10

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(desc_file, "r") as fh:
 
 setup(
     name="casbin_couchbase_adapter",
-    version="0.1.3",
+    version="0.1.4",
     author='ScienceLogic',
     url="https://github.com/ScienceLogic/casbin-couchbase-adapter",
     description="Couchbase Adapter for PyCasbin",


### PR DESCRIPTION
The last versions of pip=~21.3.1 have dependencies resolver that is more restrictive than before, so the requirements of supporting modules need to be loosen