### PR TITLE
abac custom function support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(desc_file, "r") as fh:
 
 setup(
     name="casbin_couchbase_adapter",
-    version="0.1.3",
+    version="0.1.4",
     author='ScienceLogic',
     url="https://github.com/ScienceLogic/casbin-couchbase-adapter",
     description="Couchbase Adapter for PyCasbin",


### PR DESCRIPTION
#This change support abac custom function policy.

`
p,developer,/api/main,*
p2,"customFunction(r2.sub.key,r2.sub.ip,'execute')",/api/main,POST
`
