### PR TITLE
Bugfix load policies as they were saved even with commas

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
 description-file = README.md
-version = 0.2.0
+version = 0.3.0
 


### PR DESCRIPTION
### This is to cover possible scenarios in which a policy could contain a comma that is not a delimiter

If comma was set as delimiter, it's expected that the policy values were split by a comma. But to avoid this kind of scenarios https://github.com/casbin/pycasbin/pull/292 in which logic had to be added to escape or validated how the policy needs to be split, we can load the policies as they were saved into the database.

That is why this was submitted as a bugfix, as currently the following scenarios is happening:

- The process to save the policies is working as expected, all the fields were saved into a different values like for example: `values = ["name, surname", "another_value"]`
- When loading those values, we actually had a the following `"name, surname, another_value"` when requesting data for  `get_grouping_policy` or `get_roles_for_user`, which was of course returning incorrect values
